### PR TITLE
Don't insert duplicate ip addresses to the openvpn config file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,7 +91,7 @@ printf "\n * Adding IP addresses of $PIADOMAIN to /openvpn-$PROTOCOL-$ENCRYPTION
 for ip in $VPNIPS
 do
     printf "\n     remote $ip $PORT"
-    echo "remote $ip $PORT" >> "/openvpn-$PROTOCOL-$ENCRYPTION/$REGION.ovpn"
+    grep "remote $ip $PORT" "/openvpn-$PROTOCOL-$ENCRYPTION/$REGION.ovpn" || echo "remote $ip $PORT" >> "/openvpn-$PROTOCOL-$ENCRYPTION/$REGION.ovpn"
 done
 printf "\n * Deleting all iptables rules..."
 iptables --flush


### PR DESCRIPTION
A new set of IP addresses is appended on each restart of the container which eventually results in the openvpn error `Maximum number of 'remote' options (64) exceeded.`
