### PR TITLE
Make forwarded_port file location configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ENV USER= \
     UNBLOCK= \
     EXTRA_SUBNETS= \
     PORT_FORWARDING=false \
+    PORT_FORWARDING_STATUS_FILE="/forwarded_port" \
     PROXY=on \
     PROXY_LOG_LEVEL=Critical \
     PROXY_PORT=8888 \

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ docker run --rm --network=container:pia alpine:3.10 wget -qO- https://ipinfo.io
 | `UNBLOCK` | | comma separated string (i.e. `web.com,web2.ca`) to unblock hostnames |
 | `EXTRA_SUBNETS` | | comma separated subnets allowed in the container firewall (i.e. `192.168.1.0/24,192.168.10.121,10.0.0.5/28`) |
 | `PORT_FORWARDING` | false | Set to `true` to read the forwarded port |
+| `PORT_FORWARDING_STATUS_FILE` | /forwarded_port | Set to the file where you want to write the forwarded port |
 | `PROXY` | `on` | `on` or `off`, to switch the internal HTTP proxy |
 | `PROXY_LOG_LEVEL` | `Critical` | `Info`, `Warning`, `Error` or `Critical` |
 | `PROXY_PORT` | `8888` | `1024` to `65535` internal port for HTTP proxy |
@@ -240,7 +241,7 @@ There are various ways to achieve this, depending on your use case.
 
 ## Port forwarding
 
-By setting `PORT_FORWARDING` environment variable to `true`, the forwarded port will be read and written to `/forwarded_port`.
+By setting `PORT_FORWARDING` environment variable to `true`, the forwarded port will be read and written to the file specified in `PORT_FORWARDING_STATUS_FILE` (by default, this is set to `/forwarded_port`). If the location for this file does not exist, it will be created automatically.
 
 You can mount this file as a volume to read it from other containers.
 

--- a/portforward.sh
+++ b/portforward.sh
@@ -20,9 +20,12 @@ if [ "$json" == "" ]; then
   exit 1
 fi
 port=`echo $json | jq .port`
-port_file="/forwarded_port"
-echo "$port" > $port_file
-printf " * Written forwarded port to $port_file\n"
+port_status_folder=`dirname "${PORT_FORWARDING_STATUS_FILE}"`
+if [ ! -d "${port_status_folder}" ];
+  mkdir -p "${port_status_folder}"
+fi
+echo "$port" > "${PORT_FORWARDING_STATUS_FILE}"
+printf " * Written forwarded port to ${PORT_FORWARDING_STATUS_FILE}\n"
 ip=`wget -qO- https://diagnostic.opendns.com/myip`
 exitOnError $? "Unable to read remote VPN IP"
 printf " * Forwarded port is $port on remote VPN IP $ip\n"


### PR DESCRIPTION
When running this container in a Kubernetes pod, it is not possible to directly mount the `/forwarded_port` file from other containers in the pod.

Normally this can be accomplished by creating a shared volume, and mounting this volume in all required containers. Because this container writes the file to `/` by default, it is currently impossible to use this technique, as it would try to mount the given volume on the root filesystem.

This pull request makes the folder in which the file is written configurable, so that a subfolder of the root filesystem can be used.