### PR TITLE
Shadowsocks proxy built-in, fixes #30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,17 @@ ENV USER= \
     TINYPROXY_LOG=Critical \
     TINYPROXY_PORT=8888 \
     TINYPROXY_USER= \
-    TINYPROXY_PASSWORD=
+    TINYPROXY_PASSWORD= \
+    SHADOWSOCKS=on \
+    SHADOWSOCKS_LOG=on \
+    SHADOWSOCKS_PORT=8388 \
+    SHADOWSOCKS_PASSWORD=
 ENTRYPOINT /entrypoint.sh
-EXPOSE 8888
+EXPOSE 8888/tcp 8388/tcp 8388/udp
 HEALTHCHECK --interval=3m --timeout=3s --start-period=20s --retries=1 CMD /healthcheck.sh
 RUN apk add -q --progress --no-cache --update openvpn wget ca-certificates iptables unbound unzip tinyproxy jq && \
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    apk add -q --progress --no-cache --update shadowsocks-libev && \
     wget -q https://www.privateinternetaccess.com/openvpn/openvpn.zip \
     https://www.privateinternetaccess.com/openvpn/openvpn-strong.zip \
     https://www.privateinternetaccess.com/openvpn/openvpn-tcp.zip \
@@ -65,9 +71,10 @@ RUN apk add -q --progress --no-cache --update openvpn wget ca-certificates iptab
     rm -f /tmp/*
 COPY unbound.conf /etc/unbound/unbound.conf
 COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
+COPY shadowsocks.json /etc/shadowsocks.json
 COPY entrypoint.sh healthcheck.sh portforward.sh /
 RUN chown nonrootuser -R /etc/unbound /etc/tinyproxy && \
     chmod 700 /etc/unbound /etc/tinyproxy && \
-    chmod 600 /etc/unbound/unbound.conf /etc/tinyproxy/tinyproxy.conf && \
+    chmod 600 /etc/unbound/unbound.conf /etc/tinyproxy/tinyproxy.conf /etc/shadowsocks.json && \
     chmod 500 /entrypoint.sh /healthcheck.sh /portforward.sh && \
     chmod 400 /etc/unbound/root.hints /etc/unbound/root.key /etc/unbound/*.bz2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 services:
   pia:
     build: https://github.com/qdm12/private-internet-access-docker.git
@@ -12,7 +12,9 @@ services:
     init: true
     ports:
       - 8888:8888/tcp
-    # command: 
+      - 8388:8388/tcp
+      - 8388:8388/udp
+    # command:
     environment:
       - USER=js89ds7
       - PASSWORD=8fd9s239G
@@ -26,9 +28,11 @@ services:
       - UNBLOCK=
       - FIREWALL=on
       - EXTRA_SUBNETS=
-      - PROXY=on
-      - PROXY_LOG_LEVEL=Critical
-      - PROXY_USER=
-      - PROXY_PASSWORD=
+      - TINYPROXY=on
+      - TINYPROXY_LOG=Critical
+      - TINYPROXY_USER=
+      - TINYPROXY_PASSWORD=
+      - SHADOWSOCKS=on
+      - SHADOWSOCKS_LOG=on
+      - SHADOWSOCKS_PASSWORD=
     restart: always
- 

--- a/shadowsocks.json
+++ b/shadowsocks.json
@@ -1,0 +1,14 @@
+{
+    "server": "0.0.0.0",
+    "user": "nonrootuser",
+    "method": "chacha20-ietf-poly1305",
+    "timeout": 30,
+    "fast_open": false,
+    "mode": "tcp_and_udp",
+    "port_password": {
+        "8388": ""
+    },
+    "workers": 2,
+    "interface": "tun",
+    "nameserver": "127.0.0.1"
+}


### PR DESCRIPTION
- Supports DNS queries
- Can tunnel both UDP and TCP system wide
- Clients are available on all platforms: linux, android, windows, etc.