### PR TITLE
Account for non-unix file endings in blocklist addresses

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -238,6 +238,7 @@ if [ "$DOT" == "on" ]; then
     rm /etc/unbound/blocks-nsa.conf
     sort -u -o /etc/unbound/blocks-malicious.conf /etc/unbound/blocks-malicious.conf
   fi
+  dos2unix /etc/unbound/blocks-malicious.conf
   for hostname in ${UNBLOCK//,/ }
   do
     printf "[INFO] Unblocking hostname $hostname\n"


### PR DESCRIPTION
Was getting the following error when running the image:
  /etc/unbound/blocks-malicious.conf:446: error: newline inside quoted string, no end "
  /etc/unbound/blocks-malicious.conf:447: error: stray '"'
  /etc/unbound/blocks-malicious.conf:447: error: unknown keyword 'static'
  /etc/unbound/blocks-malicious.conf:448: error: syntax error

Upon debugging to submit an issue, I found that the blocks-nsa.conf file contained non-unix compatible line endings in the quoted string addresses.  This must have been a recent change (because the image previously worked).  

Looking at https://raw.githubusercontent.com/qdm12/updated/master/files/nsa-hostnames.updated
and https://raw.githubusercontent.com/qdm12/updated/master/files/malicious-hostnames.updated, it is easy to see that the nsa-hostnames have different line endings than the malicious-hostnames.

To account for this line ending issue, run dos2unix on the blocks-malicious.conf file to remove potentially non-unix bits from the addresses so unbound doesn't complain. 