### PR TITLE
Update to function as Kubernetes sidecar container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV USER= \
 ENTRYPOINT /entrypoint.sh
 EXPOSE 8888/tcp 8388/tcp 8388/udp
 HEALTHCHECK --interval=3m --timeout=3s --start-period=20s --retries=1 CMD /healthcheck.sh
-RUN apk add -q --progress --no-cache --update openvpn wget ca-certificates iptables unbound unzip tinyproxy jq tzdata && \
+RUN apk add -q --progress --no-cache --update openvpn wget ca-certificates iptables unbound unzip tinyproxy jq tzdata sipcalc && \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk add -q --progress --no-cache --update shadowsocks-libev && \
     wget -q https://www.privateinternetaccess.com/openvpn/openvpn.zip \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -346,8 +346,9 @@ INTERFACE=$(ip r | grep 'default via' | cut -d" " -f 5)
 exitOnError $?
 printf "$INTERFACE\n"
 printf " * Detecting local subnet..."
-SUBNET=$(ip r | grep -v 'default via' | grep $INTERFACE | tail -n 1 | cut -d" " -f 1)
-exitOnError $?
+NETWORK=$(sipcalc $(ip a sh $INTERFACE | awk '/inet / {print $2}') | awk '/Network address/ { print $NF }')
+CIDR=$(sipcalc $(ip a sh $INTERFACE | awk '/inet / {print $2}') | awk '/Network mask \(bits/ { print $NF }')
+SUBNET="$NETWORK/$CIDR"
 printf "$SUBNET\n"
 for EXTRASUBNET in ${EXTRA_SUBNETS//,/ }
 do
@@ -434,8 +435,8 @@ do
   exitOnError $?
   printf "DONE\n"
   printf "   * Accept output traffic through $INTERFACE to $EXTRASUBNET..."
-  # iptables -A OUTPUT -o $INTERFACE -s $SUBNET -d $EXTRASUBNET -j ACCEPT
-  iptables -A OUTPUT -d $EXTRASUBNET -j ACCEPT
+  iptables -A OUTPUT -o $INTERFACE -s $SUBNET -d $EXTRASUBNET -j ACCEPT
+  # iptables -A OUTPUT -d $EXTRASUBNET -j ACCEPT
   exitOnError $?
   printf "DONE\n"
 


### PR DESCRIPTION
This change modifies the following functionality:

- `iptables` chains temporarily set to `ACCEPT` prior to performing `nslookup` on the PIA region address.
- Remove forced name resolution via `localhost`.
- Add verification step to see if `EXTRA_SUBNETS` routes already exist.
- Uncomment proper outbound `iptables` rule for `EXTRA_SUBNETS`.
- Generate the network/CIDR based on the primary interface.