### PR TITLE
Corrected GetMullvadCountry param

### DIFF
--- a/internal/params/mullvad.go
+++ b/internal/params/mullvad.go
@@ -11,7 +11,7 @@ import (
 // GetMullvadCountry obtains the country for the Mullvad server from the
 // environment variable COUNTRY
 func (p *paramsReader) GetMullvadCountry() (country models.MullvadCountry, err error) {
-	choices := append(constants.MullvadCityChoices(), "")
+	choices := append(constants.MullvadCountryChoices(), "")
 	s, err := p.envParams.GetValueIfInside("COUNTRY", choices)
 	return models.MullvadCountry(strings.ToLower(s)), err
 }


### PR DESCRIPTION
Updated getMullvadCountry param to use MullvadCountryChoices constant instead of MullvadCityChoices

Should fix issue I'm currently running into testing the new mullvad image when launching with VPNSP to mullvad (and COUNTRY either set or not)