### PR TITLE
Resolve a Few Mullvad Issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,4 +79,4 @@ RUN apk add -q --progress --no-cache --update openvpn ca-certificates iptables u
     adduser nonrootuser -D -H --uid 1000 && \
     chown nonrootuser -R /etc/unbound /etc/tinyproxy && \
     chmod 700 /etc/unbound /etc/tinyproxy
-COPY --from=builder --chown=1000:1000 /tmp/gobuild/entrypoint /entrypointex
+COPY --from=builder --chown=1000:1000 /tmp/gobuild/entrypoint /entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV VPNSP=pia \
     PORT_FORWARDING=off \
     PORT_FORWARDING_STATUS_FILE="/forwarded_port" \
     # Mullvad only
-    COUNTRY=Sweden \
+    COUNTRY=sweden \
     CITY= \
     ISP= \
     PORT= \
@@ -79,4 +79,4 @@ RUN apk add -q --progress --no-cache --update openvpn ca-certificates iptables u
     adduser nonrootuser -D -H --uid 1000 && \
     chown nonrootuser -R /etc/unbound /etc/tinyproxy && \
     chmod 700 /etc/unbound /etc/tinyproxy
-COPY --from=builder --chown=1000:1000 /tmp/gobuild/entrypoint /entrypoint
+COPY --from=builder --chown=1000:1000 /tmp/gobuild/entrypoint /entrypointex

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ docker run --rm --network=container:pia alpine:3.10 wget -qO- https://ipinfo.io
 
 | Environment variable | Default | Description |
 | --- | --- | --- |
+| `VPNSP` | `pia` | VPN Service Provider, one of `pia`, `mullvad` |
 | `REGION` | `CA Montreal` | (PIA only) one of the [PIA regions](https://www.privateinternetaccess.com/pages/network/) |
 | `COUNTRY` | `Sweden` | (Mullvad only) one of the [Mullvad countries](https://mullvad.net/en/servers/#openvpn) |
 | `CITY` |  | (Mullvad only, *optional*) one of the [Mullvad cities](https://mullvad.net/en/servers/#openvpn) |

--- a/internal/params/mullvad.go
+++ b/internal/params/mullvad.go
@@ -11,7 +11,7 @@ import (
 // GetMullvadCountry obtains the country for the Mullvad server from the
 // environment variable COUNTRY
 func (p *paramsReader) GetMullvadCountry() (country models.MullvadCountry, err error) {
-	choices := append(constants.MullvadCityChoices(), "")
+	choices := append(constants.MullvadCountryChoices(), "")
 	s, err := p.envParams.GetValueIfInside("COUNTRY", choices)
 	return models.MullvadCountry(strings.ToLower(s)), err
 }

--- a/internal/params/openvpn.go
+++ b/internal/params/openvpn.go
@@ -21,6 +21,7 @@ func (p *paramsReader) GetUser() (s string, err error) {
 	} else if len(s) == 0 {
 		return s, fmt.Errorf("USER environment variable cannot be empty")
 	}
+	s = strings.Replace(s, ' ', '', -1)
 	return s, nil
 }
 


### PR DESCRIPTION
Changes
* Added VPNSP to README
* Updated GetUser function to strip spaces, mullvad includes spaces on their site by default don't accept spaces through openvpn, so strip them for convenience if users copy/paste directly from site
* Corrected GetMullvadCountry param to use MullvadCountryChoices instead of MullvadCityChoices
* Updated Dockerfile to set COUNTRY to "sweden" by default instead of "Sweden" as the mappings in mullvad.go are all lower-case and the GetValueIfInside function from github.com/qdm12/golibs/params does not .ToLower in its comparison
  * May be worth updating that lib to .ToLower for its comparison, or have an IgnoreCase flag or something