### PR TITLE
Rename ENCRYPTION to PIA_ENCRYPTION

### DIFF
--- a/.github/workflows/buildx-branch.yml
+++ b/.github/workflows/buildx-branch.yml
@@ -1,4 +1,4 @@
-name: Buildx latest
+name: Buildx branch
 on:
   push:
     branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV VPNSP=pia \
     # PIA only
     PASSWORD= \
     REGION="CA Montreal" \
-    ENCRYPTION=strong \
+    PIA_ENCRYPTION=strong \
     PORT_FORWARDING=off \
     PORT_FORWARDING_STATUS_FILE="/forwarded_port" \
     # Mullvad only

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@
             - Allow outbound TCP 443 to github.com
             - If `DOT=on`, allow outbound TCP 853 to allow Unbound to resolve github.com and the PIA subdomain name if you use PIA.
             - If `DOT=off` and `VPNSP=pia`, allow outbound UDP 53 to your DNS provider to resolve the PIA subdomain name.
-        - If `VPNSP=pia`, `ENCRYPTION=strong` and `PROTOCOL=udp`: allow outbound UDP 1197 to the corresponding VPN server IPs
-        - If `VPNSP=pia`, `ENCRYPTION=normal` and `PROTOCOL=udp`: allow outbound UDP 1198 to the corresponding VPN server IPs
-        - If `VPNSP=pia`, `ENCRYPTION=strong` and `PROTOCOL=tcp`: allow outbound TCP 501 to the corresponding VPN server IPs
-        - If `VPNSP=pia`, `ENCRYPTION=normal` and `PROTOCOL=tcp`: allow outbound TCP 502 to the corresponding VPN server IPs
+        - If `VPNSP=pia`, `PIA_ENCRYPTION=strong` and `PROTOCOL=udp`: allow outbound UDP 1197 to the corresponding VPN server IPs
+        - If `VPNSP=pia`, `PIA_ENCRYPTION=normal` and `PROTOCOL=udp`: allow outbound UDP 1198 to the corresponding VPN server IPs
+        - If `VPNSP=pia`, `PIA_ENCRYPTION=strong` and `PROTOCOL=tcp`: allow outbound TCP 501 to the corresponding VPN server IPs
+        - If `VPNSP=pia`, `PIA_ENCRYPTION=normal` and `PROTOCOL=tcp`: allow outbound TCP 502 to the corresponding VPN server IPs
         - If `VPNSP=mullvad` and `PORT=`, please refer to the mapping of Mullvad servers in [these source code lines](https://github.com/qdm12/private-internet-access-docker/blob/master/internal/constants/mullvad.go#L64-L667) to find the corresponding UDP port number and IP address(es) of your choice
         - If `VPNSP=mullvad` and `PORT=53`, allow outbound UDP 53 to the corresponding VPN server IPs, which you can fine in [the mapping of Mullvad servers](https://github.com/qdm12/private-internet-access-docker/blob/master/internal/constants/mullvad.go#L64-L667)
         - If `VPNSP=mullvad` and `PORT=80`, allow outbound TCP 80 to the corresponding VPN server IPs, which you can fine in [the mapping of Mullvad servers](https://github.com/qdm12/private-internet-access-docker/blob/master/internal/constants/mullvad.go#L64-L667)
@@ -131,7 +131,7 @@ docker run --rm --network=container:pia alpine:3.11 wget -qO- https://ipinfo.io
 | `ISP` |  | (Mullvad only, *optional*) one of the [Mullvad ISP](https://mullvad.net/en/servers/#openvpn) |
 | `PORT` |  | (Mullvad only, *optional*) For TCP, `80` or `443`, or `53` for UDP. Leave blank for default Mullvad server port |
 | `PROTOCOL` | `udp` | `tcp` or `udp` |
-| `ENCRYPTION` | `strong` | (PIA only) `normal` or `strong` |
+| `PIA_ENCRYPTION` | `strong` | (PIA only) `normal` or `strong` or `custom` |
 | `USER` | | PIA username **or** Mullvad user ID |
 | `PASSWORD` | | Your PIA password |
 | `DOT` | `on` | `on` or `off`, to activate DNS over TLS to 1.1.1.1 |

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ You can try:
 
 ### Contributors
 
-Thanks for all the contributions, wether small or not so small!
+Thanks for all the contributions, whether small or not so small!
 
 - [@JeordyR](https://github.com/JeordyR) for testing the Mullvad version and opening a [PR with a few fixes](https://github.com/qdm12/private-internet-access-docker/pull/84/files) 👍
 - [@rorph](https://github.com/rorph) for a [PR to pick a random region for PIA](https://github.com/qdm12/private-internet-access-docker/pull/70) and a [PR to make the container work with kubernetes](https://github.com/qdm12/private-internet-access-docker/pull/69)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       # PIA only
       - REGION=CA Montreal
       - PASSWORD=8fd9s239G
-      - ENCRYPTION=strong
+      - PIA_ENCRYPTION=strong
       - PORT_FORWARDING=off
 
       # Mullvad only

--- a/internal/params/pia.go
+++ b/internal/params/pia.go
@@ -33,9 +33,18 @@ func (p *paramsReader) GetPortForwardingStatusFilepath() (filepath models.Filepa
 }
 
 // GetPIAEncryption obtains the encryption level for the PIA connection
-// from the environment variable ENCRYPTION
+// from the environment variable PIA_ENCRYPTION, and using ENCRYPTION for
+// retro compatibility
 func (p *paramsReader) GetPIAEncryption() (models.PIAEncryption, error) {
-	s, err := p.envParams.GetValueIfInside("ENCRYPTION", []string{"normal", "strong"}, libparams.Default("strong"))
+	// Retro-compatibility
+	s, err := p.envParams.GetValueIfInside("ENCRYPTION", []string{"normal", "strong", ""})
+	if err != nil {
+		return "", err
+	} else if len(s) != 0 {
+		p.logger.Warn("You are using the old environment variable ENCRYPTION, please consider changing it to PIA_ENCRYPTION")
+		return models.PIAEncryption(s), nil
+	}
+	s, err = p.envParams.GetValueIfInside("PIA_ENCRYPTION", []string{"normal", "strong"}, libparams.Default("strong"))
 	return models.PIAEncryption(s), err
 }
 


### PR DESCRIPTION
For clearer environment variables, especially since:
- it only applies to PIA (not Mullvad nor Windscribe)
- `CIPHER_ALGORITHM` and `AUTH_ALGORITHM` environment variables will be added next in #94 

The `ENCRYPTION` environment variable is still valid for retro compatibility.